### PR TITLE
5146 investigation

### DIFF
--- a/src/NHSD.BuyingCatalogue.Organisations.Api/Dockerfile
+++ b/src/NHSD.BuyingCatalogue.Organisations.Api/Dockerfile
@@ -7,10 +7,10 @@ EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /
-COPY ["src/NHSD.BuyingCatalogue.Organisations.Api/NHSD.BuyingCatalogue.Organisations.Api.csproj", "src/NHSD.BuyingCatalogue.Organisations.Api/"]
-RUN dotnet restore "src/NHSD.BuyingCatalogue.Organisations.Api/NHSD.BuyingCatalogue.Organisations.Api.csproj"
 COPY . .
+
 WORKDIR "/src/NHSD.BuyingCatalogue.Organisations.Api"
+RUN echo "DOTNET VERSION: $(dotnet --version)"
 RUN dotnet build "NHSD.BuyingCatalogue.Organisations.Api.csproj" -c Release -o /app/build
 
 FROM build AS publish

--- a/src/NHSD.BuyingCatalogue.Organisations.Api/Dockerfile
+++ b/src/NHSD.BuyingCatalogue.Organisations.Api/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /
 COPY . .
 
 WORKDIR "/src/NHSD.BuyingCatalogue.Organisations.Api"
-RUN echo "DOTNET VERSION: $(dotnet --version)"
 RUN dotnet build "NHSD.BuyingCatalogue.Organisations.Api.csproj" -c Release -o /app/build
 
 FROM build AS publish


### PR DESCRIPTION
- removed explicit restore from the dockerfile which was causing the build to fail due to .net core sdk being on v 3.1.2