### PR TITLE
enable invalid certificate when isapi is https

### DIFF
--- a/src/NHSD.BuyingCatalogue.Organisations.Api/Startup.cs
+++ b/src/NHSD.BuyingCatalogue.Organisations.Api/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using System.Net.Http;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -34,6 +35,7 @@ namespace NHSD.BuyingCatalogue.Organisations.Api
 
             var authority = Configuration.GetValue<string>("authority");
             var requireHttps = Configuration.GetValue<bool>("RequireHttps");
+            var allowInvalidCertificate = Configuration.GetValue<bool>("AllowInvalidCertificate");
 
             services.AddAuthentication(BearerToken)
                 .AddJwtBearer(BearerToken, options =>
@@ -41,6 +43,14 @@ namespace NHSD.BuyingCatalogue.Organisations.Api
                     options.Authority = authority;
                     options.RequireHttpsMetadata = requireHttps;
                     options.Audience = "Organisation";
+                    if (allowInvalidCertificate)
+                    {
+                        options.BackchannelHttpHandler = new HttpClientHandler
+                        {
+                            ServerCertificateCustomValidationCallback =
+                                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+                        };
+                    }
                 });
 
             services.AddControllers();

--- a/src/NHSD.BuyingCatalogue.Organisations.Api/appsettings.Development.json
+++ b/src/NHSD.BuyingCatalogue.Organisations.Api/appsettings.Development.json
@@ -1,9 +1,3 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  }
+  "AllowInvalidCertificate": true
 }

--- a/src/NHSD.BuyingCatalogue.Organisations.Api/appsettings.json
+++ b/src/NHSD.BuyingCatalogue.Organisations.Api/appsettings.json
@@ -1,6 +1,7 @@
 {
   "Authority": "http://localhost:52598/",
   "RequireHttps": false,
+  "AllowInvalidCertificate": false,
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
What in node is a simple environment variable in c# is a pain.
The API calls the known configuration end point on isapi.
Unfortunately, when the certificate is invalid it fails, which breaks in the dev environment.
After some hunting, the way to solve it is to override the back channel http handler.
This happens when isapi is hosted via ingress in dev, and we use the nginx self signed certificate.