### PR TITLE
5621: Add config for dev env and dev-docker env

### DIFF
--- a/docker-compose-build.yml
+++ b/docker-compose-build.yml
@@ -21,3 +21,9 @@ services:
     container_name: identity_api_user_db
     build: 
       context: src/NHSD.BuyingCatalogue.Identity.UserDatabase
+
+  nhsd.buyingcatalogue.email:
+    image: ${REGISTRY:-nhsd}/buying-catalogue/smtp-server:${TAG:-latest}
+    container_name: smtp_server
+    build: 
+      context: src/NHSD.BuyingCatalogue.Smtp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - "${NHSD_LOCAL_DB_PORT:-1533}:1433"
       
   nhsd.buyingcatalogue.identity.api:
-    image: ${REGISTRY:-nhsd}/buying-catalogue/identity-api:${TAG:-latest}
+    image: ${REGISTRY:-nhsd}/buying-catalogue/identity-isapi:${TAG:-latest}
     container_name: identity_api
     build: 
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - "8070:80"
 
   nhsd.buyingcatalogue.identity.api.broken:
-    image: ${REGISTRY:-nhsd}/buying-catalogue/identity-api:${TAG:-latest}
+    image: ${REGISTRY:-nhsd}/buying-catalogue/identity-isapi:${TAG:-latest}
     container_name: identity_api_broken
     environment:
       - ASPNETCORE_ENVIRONMENT=Development

--- a/src/NHSD.BuyingCatalogue.Organisations.Api/Properties/launchSettings.json
+++ b/src/NHSD.BuyingCatalogue.Organisations.Api/Properties/launchSettings.json
@@ -3,17 +3,17 @@
     "NHSD.BuyingCatalogue.Organisations.Api": {
       "commandName": "Project",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "SmtpServer__Port": "587"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:55075"
+      "applicationUrl": "http://localhost:5103"
     },
     "NHSD.BuyingCatalogue.Organisations.Api Docker": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "ConnectionStrings__CatalogueUsers": "Data Source=localhost,1533;Initial Catalog=CatalogueUsers;MultipleActiveResultSets=true;User ID=NHSD;Password=DisruptTheMarket1!"
+        "ConnectionStrings__CatalogueUsers": "Data Source=localhost,1533;Initial Catalog=CatalogueUsers;MultipleActiveResultSets=true;User ID=NHSD;Password=DisruptTheMarket1!",
+        "SmtpServer__Port": "1587"
       },
       "applicationUrl": "http://localhost:5103"
     }

--- a/src/NHSD.BuyingCatalogue.Organisations.Api/appsettings.json
+++ b/src/NHSD.BuyingCatalogue.Organisations.Api/appsettings.json
@@ -15,7 +15,7 @@
   },
   "SmtpServer": {
     "Host": "localhost",
-    "Port": 1587,
+    "Port": 587,
     "Authentication": {
       "IsRequired": false
     }


### PR DESCRIPTION
- oapi now starts on 5103 when running locally
- switched default config in favour of using helm over docker for service dependencies
- 'useLocalImage: true' in helm's local overrides will now work as intended.
- build & push local smtp server to the acr as part of the build pipeline