### PR TITLE
Add user agreement page and corresponding logic

### DIFF
--- a/src/NHSD.BuyingCatalogue.Identity.Api/Controllers/ConsentController.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Controllers/ConsentController.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading.Tasks;
+using IdentityServer4.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using NHSD.BuyingCatalogue.Identity.Api.Services;
+using NHSD.BuyingCatalogue.Identity.Api.ViewModels.Consent;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.Controllers
+{
+    public sealed class ConsentController : Controller
+    {
+        private readonly IAgreementConsentService _consentService;
+
+        public ConsentController(IAgreementConsentService consentService)
+        {
+            _consentService = consentService ?? throw new ArgumentNullException(nameof(consentService));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> Index(Uri returnUrl)
+        {
+            if (returnUrl is null)
+                throw new ArgumentNullException(nameof(returnUrl));
+
+            if (await _consentService.IsValidReturnUrl(returnUrl))
+                return View(new ConsentViewModel { ReturnUrl = returnUrl });
+
+            return View("Error");
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Index(ConsentViewModel model)
+        {
+            if (model is null)
+                throw new ArgumentNullException(nameof(model));
+
+            if (!ModelState.IsValid)
+                return View(model);
+
+            var returnUrl = model.ReturnUrl;
+
+            var result = await _consentService.GrantConsent(returnUrl, User.GetSubjectId());
+            if (result.IsSuccess)
+                return Redirect(returnUrl.ToString());
+
+            return View("Error");
+        }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Infrastructure/CatalogueAgreementConsentStore.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Infrastructure/CatalogueAgreementConsentStore.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Threading.Tasks;
+using IdentityServer4.Models;
+using IdentityServer4.Stores;
+using NHSD.BuyingCatalogue.Identity.Api.Repositories;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.Infrastructure
+{
+    internal sealed class CatalogueAgreementConsentStore : IUserConsentStore
+    {
+        private readonly IScopeRepository _scopeRepository;
+        private readonly IUsersRepository _userRepository;
+
+        public CatalogueAgreementConsentStore(IScopeRepository scopeRepository, IUsersRepository usersRepository)
+        {
+            _scopeRepository = scopeRepository ?? throw new ArgumentNullException(nameof(scopeRepository));
+            _userRepository = usersRepository ?? throw new ArgumentNullException(nameof(usersRepository));
+        }
+
+        public async Task StoreUserConsentAsync(Consent consent)
+        {
+            if (consent == null)
+                throw new ArgumentNullException(nameof(consent));
+
+            var user = await _userRepository.GetByIdAsync(consent.SubjectId);
+            user.MarkCatalogueAgreementAsSigned();
+            await _userRepository.UpdateAsync(user);
+        }
+
+        public async Task<Consent> GetUserConsentAsync(string subjectId, string clientId)
+        {
+            var user = await _userRepository.GetByIdAsync(subjectId);
+
+            return new Consent
+            {
+                ClientId = clientId,
+                CreationTime = DateTime.UtcNow,
+                Expiration = DateTime.MaxValue,
+                Scopes = user.CatalogueAgreementSigned
+                    ? _scopeRepository.Scopes
+                    : null,
+                SubjectId = subjectId,
+            };
+        }
+
+        public Task RemoveUserConsentAsync(string subjectId, string clientId)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Infrastructure/CatalogueAgreementConsentStore.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Infrastructure/CatalogueAgreementConsentStore.cs
@@ -19,7 +19,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Infrastructure
 
         public async Task StoreUserConsentAsync(Consent consent)
         {
-            if (consent == null)
+            if (consent is null)
                 throw new ArgumentNullException(nameof(consent));
 
             var user = await _userRepository.GetByIdAsync(consent.SubjectId);

--- a/src/NHSD.BuyingCatalogue.Identity.Api/NHSD.BuyingCatalogue.Identity.Api.csproj
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/NHSD.BuyingCatalogue.Identity.Api.csproj
@@ -27,6 +27,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/src/NHSD.BuyingCatalogue.Identity.Api/NHSD.BuyingCatalogue.Identity.Api.csproj
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/NHSD.BuyingCatalogue.Identity.Api.csproj
@@ -27,7 +27,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Repositories/IScopeRepository.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Repositories/IScopeRepository.cs
@@ -4,6 +4,6 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Repositories
 {
     public interface IScopeRepository
     {
-        IEnumerable<string> Scopes { get; }
+        IReadOnlyCollection<string> Scopes { get; }
     }
 }

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Repositories/IScopeRepository.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Repositories/IScopeRepository.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.Repositories
+{
+    public interface IScopeRepository
+    {
+        IEnumerable<string> Scopes { get; }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Repositories/ScopeRepository.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Repositories/ScopeRepository.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using NHSD.BuyingCatalogue.Identity.Api.Settings;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.Repositories
+{
+    internal sealed class ScopeRepository : IScopeRepository
+    {
+        private readonly List<string> _scopes = new List<string>();
+
+        [SuppressMessage(
+            "Globalization",
+            "CA1308:Normalize strings to uppercase",
+            Justification = "OpenId scopes are lower case and must match")]
+        public ScopeRepository(
+            IEnumerable<ResourceSetting> apiResources,
+            IEnumerable<IdentityResourceSetting> identityResources)
+        {
+            if (apiResources != null)
+                _scopes.AddRange(apiResources.Select(r => r.ResourceName));
+
+            if (identityResources != null)
+                _scopes.AddRange(identityResources.Select(r => r.ResourceType.ToLowerInvariant()));
+        }
+
+        public IEnumerable<string> Scopes => _scopes;
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Repositories/ScopeRepository.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Repositories/ScopeRepository.cs
@@ -24,6 +24,6 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Repositories
                 _scopes.AddRange(identityResources.Select(r => r.ResourceType.ToLowerInvariant()));
         }
 
-        public IEnumerable<string> Scopes => _scopes;
+        public IReadOnlyCollection<string> Scopes => _scopes;
     }
 }

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Services/AgreementConsentService.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Services/AgreementConsentService.cs
@@ -38,7 +38,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Services
                 throw new ArgumentNullException(nameof(returnUrl));
 
             var context = await _interaction.GetAuthorizationContextAsync(returnUrl.ToString());
-            if (context == null)
+            if (context is null)
                 return Result.Failure<Uri>();
 
             var consent = new ConsentResponse

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Services/AgreementConsentService.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Services/AgreementConsentService.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Threading.Tasks;
+using IdentityServer4.Events;
+using IdentityServer4.Models;
+using IdentityServer4.Services;
+using NHSD.BuyingCatalogue.Identity.Api.Repositories;
+using NHSD.BuyingCatalogue.Identity.Common.Results;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.Services
+{
+    internal sealed class AgreementConsentService : IAgreementConsentService
+    {
+        private readonly IEventService _eventService;
+        private readonly IIdentityServerInteractionService _interaction;
+        private readonly IScopeRepository _scopeRepository;
+
+        public AgreementConsentService(
+            IEventService eventService,
+            IIdentityServerInteractionService interaction,
+            IScopeRepository scopeRepository)
+        {
+            _eventService = eventService ?? throw new ArgumentNullException(nameof(eventService));
+            _interaction = interaction ?? throw new ArgumentNullException(nameof(interaction));
+            _scopeRepository = scopeRepository ?? throw new ArgumentNullException(nameof(scopeRepository));
+        }
+
+        public async Task<bool> IsValidReturnUrl(Uri returnUrl)
+        {
+            if (returnUrl is null)
+                throw new ArgumentNullException(nameof(returnUrl));
+
+            return await _interaction.GetAuthorizationContextAsync(returnUrl.ToString()) != null;
+        }
+
+        public async Task<Result<Uri>> GrantConsent(Uri returnUrl, string subjectId)
+        {
+            if (returnUrl is null)
+                throw new ArgumentNullException(nameof(returnUrl));
+
+            var context = await _interaction.GetAuthorizationContextAsync(returnUrl.ToString());
+            if (context == null)
+                return Result.Failure<Uri>();
+
+            var consent = new ConsentResponse
+            {
+                RememberConsent = true,
+                ScopesConsented = _scopeRepository.Scopes,
+            };
+
+            await _interaction.GrantConsentAsync(context, consent);
+            await _eventService.RaiseAsync(new ConsentGrantedEvent(
+                subjectId,
+                context.ClientId,
+                context.ScopesRequested,
+                _scopeRepository.Scopes,
+                true));
+
+            return Result.Success(returnUrl);
+        }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Services/IAgreementConsentService.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Services/IAgreementConsentService.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Threading.Tasks;
+using NHSD.BuyingCatalogue.Identity.Common.Results;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.Services
+{
+    public interface IAgreementConsentService
+    {
+        Task<bool> IsValidReturnUrl(Uri returnUrl);
+
+        Task<Result<Uri>> GrantConsent(Uri returnUrl, string subjectId);
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Identity.Api/ViewModels/Consent/ConsentViewModel.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/ViewModels/Consent/ConsentViewModel.cs
@@ -6,7 +6,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.ViewModels.Consent
 {
     public sealed class ConsentViewModel
     {
-        // TODO: confirm correct error message
+        // TODO: 6329 – confirm correct error message
         [Required]
         [RegularExpression(
             "(?:True|true)",

--- a/src/NHSD.BuyingCatalogue.Identity.Api/ViewModels/Consent/ConsentViewModel.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/ViewModels/Consent/ConsentViewModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.ViewModels.Consent
+{
+    public sealed class ConsentViewModel
+    {
+        // TODO: confirm correct error message
+        [Required]
+        [RegularExpression(
+            "(?:True|true)",
+            ErrorMessage = "You must agree to the terms and conditions before continuing.")]
+        [DisplayName("I agree with the terms")]
+        public bool AgreeWithTerms { get; set; }
+
+        public Uri ReturnUrl { get; set; }
+    }
+}

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Views/Consent/Index.cshtml
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Views/Consent/Index.cshtml
@@ -1,0 +1,198 @@
+﻿@model NHSD.BuyingCatalogue.Identity.Api.ViewModels.Consent.ConsentViewModel
+
+@{
+    ViewData["PageTitle"] = "User agreement";
+    ViewData["PageDescription"] = "PLEASE READ THESE TERMS CAREFULLY BEFORE USING THE CATALOGUE";
+}
+
+<style>
+    .decimal-list {
+        list-style-type: decimal
+    }
+
+    .lower-alpha-list {
+        list-style-type: lower-alpha
+    }
+
+    .lower-roman-list {
+        list-style-type: lower-roman
+    }
+
+    .upper-alpha-list {
+        list-style-type: upper-alpha
+    }
+</style>
+
+<div class="nhsuk-width-container">
+    <main class="nhsuk-main-wrapper">
+        <div data-test-id="login-page">
+            <div class="nhsuk-grid-row">
+                <div class="nhsuk-grid-column-two-thirds">
+                    <div data-test-id="error-summary" nhs-validation-summary title="There is a problem"></div>
+                    <h1 data-test-id="page-title" class="nhsuk-heading-xl nhsuk-u-margin-bottom-2">@ViewData["PageTitle"]</h1>
+                    <h2 data-test-id="page-description" class="nhsuk-heading-s nhsuk-u-margin-bottom-5">@ViewData["PageDescription"]</h2>
+
+                    <ol class="decimal-list">
+                        <li>
+                            Background
+                            <ol class="lower-alpha-list">
+                                <li>
+                                    https://buyingcatalogue.digital.nhs.uk, known as the <b>"Catalogue"</b>, is a website that is:
+                                    <ol class="lower-roman-list">
+                                        <li>used by suppliers to undergo compliance processes and market, and sell, digital services; and</li>
+                                        <li>used by potential buyers of those services, such as Clinical Commissioning Groups, to inform their purchasing decisions for various digital services.</li>
+                                    </ol>
+                                </li>
+                                <li>The Catalogue is operated by NHS Digital (<b>"we", "us", "our"</b>).</li>
+                                <li>You are an individual named/authorised to use the Catalogue via a login and password by a company or organisation which has signed a contract with us as a Supplier or a Buyer (the <b>"Catalogue Buyers' Terms of Use"</b> for buyers of products and services from the Catalogue, and <b>"Catalogue Agreement"</b> for suppliers of the products and services on the Catalogue.</li>
+                                <li>You will also be bound by the terms of your company's/organisation’s agreement with us and any instructions laid down by the company/organisation you represent.</li>
+                                <li>You must keep passwords for access to the Catalogue private and confidential.</li>
+                                <li>These Catalogue General Terms of Use set out the standards that apply when you access the Catalogue, add content to the Catalogue, make contact with other users on our Catalogue, link to our Catalogue, or interact with our Catalogue in any other way.</li>
+                            </ol>
+                        </li>
+                        <li>
+                            Acceptance of these terms
+                            <ol class="lower-alpha-list">
+                                <li>By registering an account and accepting these terms and then using the Catalogue, you confirm on a continuing basis that you accept and will comply with these Catalogue General Terms of Use.</li>
+                                <li>If you do not agree to these Catalogue General Terms of Use, you must not use the Catalogue, and if you are a Registered User your organisation will be in breach of the Catalogue Agreement if you continue to use the Catalogue in those circumstances.</li>
+                            </ol>
+                        </li>
+                        <li>
+                            How we make changes to the terms
+                            <ol class="lower-alpha-list">
+                                <li>We may amend these Catalogue General Terms of Use from time to time and will maintain and publish version control details.</li>
+                                <li>Each time you wish to use our Catalogue, please check the Catalogue General Terms of Use to ensure you understand the terms that apply at that time.</li>
+                                <li>Each time you access the Catalogue, by continuing your use you will be accepting the current version of these Catalogue General Terms of Use.</li>
+                            </ol>
+                        </li>
+                        <li>
+                            Scope of use
+                            <ol class="lower-alpha-list">
+                                <li>We grant a non-exclusive, non-transferable, royalty free licence to you to connect to the Catalogue to view authorised parts of the Catalogue.</li>
+                                <li>
+                                    You may use our Catalogue only for lawful purposes. You may not use our Catalogue:
+                                    <ol class="lower-alpha-list">
+                                        <li>in any way that breaches any applicable local, national or international law or regulation;</li>
+                                        <li>in any way that is unlawful or fraudulent, or has any unlawful or fraudulent purpose or effect;</li>
+                                        <li>for the purpose of harming or attempting to harm minors in any way;</li>
+                                        <li>to send, knowingly receive, upload, download, use or re-use any material which does not comply with our content standards as set out at paragraph 8;</li>
+                                        <li>to transmit, or procure the sending of, any unsolicited or unauthorised advertising or promotional material or any other form of similar solicitation (spam); or</li>
+                                        <li>to knowingly transmit any data, send or upload any material that contains viruses, Trojan horses, worms, time-bombs, keystroke loggers, spyware, adware or any other harmful programs or similar computer code designed to adversely affect the operation of any computer software or hardware.</li>
+                                    </ol>
+                                </li>
+                                <li>
+                                    You also agree that you shall not:
+                                    <ol class="lower-alpha-list">
+                                        <li>reproduce, duplicate, copy or re-sell any part of our Catalogue;</li>
+                                        <li>
+                                            attempt to:
+                                            <ol class="upper-alpha-list">
+                                                <li>copy, adapt, duplicate, modify, create derivative works from or distribute all or any portion of any application program interface technology you access through the Catalogue; or</li>
+                                                <li>reverse compile, decompile, disassemble, reverse engineer or otherwise reduce to human-perceivable form all or any part of the Catalogue; or</li>
+                                                <li>make changes or error corrections to the Catalogue in whole or in part;</li>
+                                            </ol>
+                                        </li>
+                                        <li>
+                                            access without authority, interfere with, damage or disrupt:
+                                            <ol class="upper-alpha-list">
+                                                <li>any part of our Catalogue;</li>
+                                                <li>any equipment or network on which our Catalogue is stored;</li>
+                                                <li>any software used in the provision of our Catalogue; or</li>
+                                                <li>any equipment or network or software owned or used by any third party.</li>
+                                            </ol>
+                                        </li>
+                                    </ol>
+                                </li>
+                                <li>You accept that all intellectual property rights created and developed by us which subsist or are used in, or in connection with, the Catalogue and the specification of the functional capabilities and the associated standards mapped to the functional capabilities will be our absolute property and will vest and remain vested in us.</li>
+                            </ol>
+                        </li>
+                        <li>
+                            Interactive services
+                            <ol class="lower-alpha-list">
+                                <li>
+                                    We may from time to time provide interactive services to Registered Users, including, without limitation:
+                                    <ol class="lower-roman-list">
+                                        <li>sharing reviews of the digital products and services on the Catalogue by customers;</li>
+                                        <li>chat rooms; and</li>
+                                        <li>bulletin boards,</li>
+                                    </ol>
+                                    (the <b>"Interactive Services"</b>).
+                                </li>
+                                <li>Where we do provide any Interactive Service, we will provide clear information to you about the kind of service offered, if it is moderated and what form of moderation is used (including whether it is human or technical).</li>
+                                <li>We will do our best to assess any possible risks for users from third parties when they use any Interactive Service provided on our Catalogue, and we will decide in each case whether it is appropriate to use moderation of the relevant service (including what kind of moderation to use) in the light of those risks. However, we are under no obligation to oversee, monitor or moderate any Interactive Service we provide on our Catalogue, and we expressly exclude our liability for any loss or damage arising from the use of any interactive service by a user in contravention of our content standards, whether the service is moderated or not.</li>
+                                <li>Where we do moderate an Interactive Service, we will normally provide you with a means of contacting the moderator, should a concern or difficulty arise.</li>
+                            </ol>
+                        </li>
+                        <li>
+                            Content standards
+                            <ol class="lower-alpha-list">
+                                <li>These content standards apply to any and all material which you contribute to our Catalogue, including any information it provides in relation to an Interactive Service (<b>"Contribution"</b>).</li>
+                                <li>The content standards must be complied with in spirit as well as to the letter. The standards apply to each part of any Contribution as well as to its whole.</li>
+                                <li>We will determine, in its discretion and acting reasonably, whether a Contribution breaches the content standards.</li>
+                                <li>
+                                    A Contribution must:
+                                    <ol class="lower-roman-list">
+                                        <li>be accurate (where it states facts);</li>
+                                        <li>be genuinely held (where it states opinions); and</li>
+                                        <li>comply with the law applicable in England and Wales and in any country from which it is posted.</li>
+                                    </ol>
+                                </li>
+                                <li>
+                                    A Contribution must not:
+                                    <ol class="lower-roman-list">
+                                        <li>be false or misleading;</li>
+                                        <li>be defamatory of any person;</li>
+                                        <li>be obscene, offensive, hateful or inflammatory;</li>
+                                        <li>promote sexually explicit material;</li>
+                                        <li>promote violence;</li>
+                                        <li>promote discrimination based on race, sex, religion, nationality, disability, sexual orientation or age;</li>
+                                        <li>infringe any copyright, database right or trade mark of any other person;</li>
+                                        <li>be likely to deceive any person;</li>
+                                        <li>breach any legal duty owed to a third party, such as a contractual duty or a duty of confidence;</li>
+                                        <li>promote any illegal activity;</li>
+                                        <li>be in contempt of court;</li>
+                                        <li>be threatening, abuse or invade another's privacy, or cause annoyance, inconvenience or needless anxiety;</li>
+                                        <li>be likely to harass, upset, embarrass, alarm or annoy any other person;</li>
+                                        <li>impersonate any person, or misrepresent your identity or affiliation with any person;</li>
+                                        <li>give the impression that the Contribution emanates from us, a party managing a framework agreement or any other Government body, if this is not the case;</li>
+                                        <li>advocate, promote, incite any party to commit, or assist any unlawful or criminal act such as (by way of example only) copyright infringement or computer misuse; or</li>
+                                        <li>contain a statement which you know or believe, or have reasonable grounds for believing, that members of the public to whom the statement is, or is to be, published are likely to understand as a direct or indirect encouragement or other inducement to the commission, preparation or instigation of acts of terrorism.</li>
+                                    </ol>
+                                </li>
+                            </ol>
+                        </li>
+                        <li>
+                            Data
+                            <ol class="lower-alpha-list">
+                                <li>In relation to how data from activity on the Catalogue is collected and used, please review the privacy policy for Registered Users of the Catalogue : [ ]</li>
+                            </ol>
+                        </li>
+                        <li>
+                            Disclaimers / Liability
+                            <ol class="lower-alpha-list">
+                                <li>You use the Catalogue entirely at your own risk and, to the extent permitted under the laws of England and Wales, we assume no duty of care or other legal liability or responsibility to you, or for any loss or damage suffered by you as a result of such use and shall not be liable to contribute to or otherwise share in any liability to compensate any third party harmed as a result of the usage of the Catalogue.</li>
+                                <li>The Catalogue is provided on an “as is” basis without (to the extent permitted by law) any warranty or representation of any kind either express or implied (including the implied warranties of merchantability and fitness for a particular purpose).</li>
+                                <li>We will have no liability for unavailability of the Catalogue. From time to time, the Catalogue will be unavailable due to maintenance or other technical issues.</li>
+                                <li>We have not verified the information available in the Catalogue Solution listing and will not be held responsible for errors.</li>
+                                <li>To the extent permissible by the laws of England and Wales, we shall not be liable for any direct, special, indirect or consequential losses and/or damages nor for any loss (whether direct or indirect) of use, data, business or profits arising out of or in connection with these Catalogue General Terms of Use, whether such liability arises from any claim based upon contract, warranty, tort (including negligence), strict liability or otherwise, and whether or not we have been advised of the possibility of such loss or damage.</li>
+                                <li>Our financial liability in connection with these Catalogue General Terms of Use to you shall be limited to £50.</li>
+                            </ol>
+                        </li>
+                        <li>
+                            Which country's laws apply to any disputes?
+                            <p>These Catalogue General Terms of Use, the subject matter and the formation (and any non-contractual disputes or claims), are governed by the laws of England and Wales and subject to the jurisdiction of the courts of England.</p>
+                        </li>
+                    </ol>
+                    <form asp-controller="Consent" asp-action="Index" asp-route-returnUrl="@ViewData["ReturnUrl"]" method="post">
+                        <input type="hidden" asp-for="ReturnUrl" />
+
+                        <span data-test-id="agreement-error-message" asp-validation-for="AgreeWithTerms" class="nhsuk-error-message"></span>
+                        <input type="checkbox" asp-for="AgreeWithTerms" />
+                        <label asp-for="AgreeWithTerms"></label>
+                        <button class="nhsuk-button nhsuk-u-margin-top-5 nhsuk-u-margin-bottom-3" type="submit" data-test-id="agreement-submit-button">Continue</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </main>
+</div>

--- a/src/NHSD.BuyingCatalogue.Identity.Api/appsettings.Development.json
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/appsettings.Development.json
@@ -8,7 +8,7 @@
       "allowOfflineAccess": false,
       "requireClientSecret": true,
       "secret": "SampleClientSecret",
-      "requireConsent": false,
+      "requireConsent": true,
       "redirectUrls": [ "http://localhost:49176/signin-oidc", "https://host.docker.internal/admin/oauth/callback" ],
       "postLogoutRedirectUrls": [ "http://localhost:49176/signout-callback-oidc" ],
       "allowedScopes": [ "openid", "email", "profile", "SampleResource", "Organisation" ]
@@ -21,7 +21,7 @@
       "allowOfflineAccess": false,
       "requireClientSecret": true,
       "secret": "MvcSecret",
-      "requireConsent": false,
+      "requireConsent": true,
       "redirectUrls": [ "http://localhost:49176/signin-oidc" ],
       "postLogoutRedirectUrls": [ "http://localhost:49176/signout-callback-oidc" ],
       "allowedScopes": [ "openid", "email", "profile", "SampleResource", "Organisation" ]
@@ -34,26 +34,10 @@
       "allowOfflineAccess": false,
       "requireClientSecret": true,
       "secret": "PasswordSecret",
-      "requireConsent": false,
+      "requireConsent": true,
       "redirectUrls": [ "http://localhost:49176/signin-oidc" ],
       "postLogoutRedirectUrls": [ "http://localhost:49176/signout-callback-oidc" ],
       "allowedScopes": [ "openid", "email", "profile", "Organisation" ]
-    }
-  ],
-  "resources": [
-    {
-      "resourceName": "SampleResource",
-      "displayName": "Sample Resource"
-    },
-    {
-      "resourceName": "Organisation",
-      "displayName": "Organisation",
-      "claimTypes": [ "organisation" ]
-    },
-    {
-      "resourceName": "Ordering",
-      "displayName": "Ordering",
-      "claimType": [ "ordering" ]
     }
   ],
   "smtpServer": {

--- a/src/NHSD.BuyingCatalogue.Identity.Api/appsettings.json
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/appsettings.json
@@ -15,7 +15,7 @@
       "requireClientSecret": true,
       "secret": "SampleClientSecret",
       "requirePkce": true,
-      "requireConsent": false,
+      "requireConsent": true,
       "redirectUrls": [ "http://localhost:3000/oauth/callback", "http://host.docker.internal:3000/oauth/callback" ],
       "postLogoutRedirectUrls": [ "http://localhost:3000/signout-callback-oidc", "http://host.docker.internal:3000/signout-callback-oidc" ],
       "allowedScopes": [ "openid", "email", "profile", "SampleResource", "Organisation" ]
@@ -25,6 +25,16 @@
     {
       "resourceName": "SampleResource",
       "displayName": "Sample Resource"
+    },
+    {
+      "resourceName": "Organisation",
+      "displayName": "Organisation",
+      "claimTypes": [ "organisation" ]
+    },
+    {
+      "resourceName": "Ordering",
+      "displayName": "Ordering",
+      "claimType": [ "ordering" ]
     }
   ],
   "identityResources": [
@@ -78,5 +88,5 @@
   "disabledErrorMessage": {
     "emailAddress": "exeter.helpdesk@nhs.net",
     "phoneNumber": "0300 303 4034"
-  } 
+  }
 }

--- a/tests/NHSD.BuyingCatalogue.Identity.Api.IntegrationTests/Steps/UserSteps.cs
+++ b/tests/NHSD.BuyingCatalogue.Identity.Api.IntegrationTests/Steps/UserSteps.cs
@@ -54,7 +54,8 @@ namespace NHSD.BuyingCatalogue.Identity.Api.IntegrationTests.Steps
                     Id = user.Id,
                     OrganisationId = organisationId,
                     OrganisationFunction = user.OrganisationFunction,
-                    SecurityStamp = "TestUser"
+                    SecurityStamp = "TestUser",
+                    CatalogueAgreementSigned = user.CatalogueAgreementSigned,
                 };
 
                 await userEntity.InsertAsync(_settings.ConnectionString);
@@ -300,6 +301,8 @@ namespace NHSD.BuyingCatalogue.Identity.Api.IntegrationTests.Steps
             public string OrganisationName { get; set; }
 
             public string OrganisationFunction { get; set; } = "Authority";
+
+            public bool CatalogueAgreementSigned { get; set; } = true;
         }
 
         private sealed class ExpectedGetUserTable

--- a/tests/NHSD.BuyingCatalogue.Identity.Api.Testing.Data/Entities/UserEntity.cs
+++ b/tests/NHSD.BuyingCatalogue.Identity.Api.Testing.Data/Entities/UserEntity.cs
@@ -24,6 +24,8 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Testing.Data.Entities
 
         public string Id { get; set; }
 
+        public bool CatalogueAgreementSigned { get; set; }
+
         protected override string InsertSql => @"
             INSERT INTO dbo.AspNetUsers
                 (Id, UserName, NormalizedUserName, Email, NormalizedEmail, EmailConfirmed,
@@ -35,7 +37,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Testing.Data.Entities
                 (@id, @email, UPPER(@email), @email, UPPER(@email), 1,
 	            @passwordHash, @securityStamp, NEWID(), @phoneNumber, 1,
 	            0, 0, 0,
-	            @organisationId, @organisationFunction, @disabled, 0,
+	            @organisationId, @organisationFunction, @disabled, @catalogueAgreementSigned,
 	            @firstName, @lastName);";
 
         protected override string GetSql => @"

--- a/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Controllers/ConsentControllerTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Controllers/ConsentControllerTests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityModel;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NHSD.BuyingCatalogue.Identity.Api.Controllers;
+using NHSD.BuyingCatalogue.Identity.Api.Services;
+using NHSD.BuyingCatalogue.Identity.Api.ViewModels.Consent;
+using NHSD.BuyingCatalogue.Identity.Common.Results;
+using NUnit.Framework;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Controllers
+{
+    [TestFixture]
+    internal sealed class ConsentControllerTests
+    {
+        [Test]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "Exception testing")]
+        public void Constructor_NullConsentService_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ConsentController(null));
+        }
+
+        [Test]
+        public void Index_Uri_NullReturnUrl_ThrowsException()
+        {
+            static async Task Index()
+            {
+                using var controller = new ConsentController(Mock.Of<IAgreementConsentService>());
+                await controller.Index((Uri)null);
+            }
+
+            Assert.ThrowsAsync<ArgumentNullException>(Index);
+        }
+
+        [Test]
+        public async Task Index_Uri_ValidReturnUrl_ReturnsConsentView()
+        {
+            var returnUrl = new Uri("http://www.goodurl.co.uk/");
+
+            var mockConsentService = new Mock<IAgreementConsentService>();
+            mockConsentService.Setup(c => c.IsValidReturnUrl(It.IsNotNull<Uri>()))
+                .ReturnsAsync(true);
+
+            using var controller = new ConsentController(mockConsentService.Object);
+
+            var result = await controller.Index(returnUrl) as ViewResult;
+
+            Assert.NotNull(result);
+            result.Model.Should().BeEquivalentTo(new ConsentViewModel { ReturnUrl = returnUrl });
+        }
+
+        [Test]
+        public async Task Index_Uri_BadReturnUrl_ReturnsErrorView()
+        {
+            using var controller = new ConsentController(Mock.Of<IAgreementConsentService>());
+
+            var result = await controller.Index(new Uri("http://www.badurl.co.uk/")) as ViewResult;
+
+            Assert.NotNull(result);
+            result.ViewName.Should().Be("Error");
+        }
+
+        [Test]
+        public void Index_ConsentViewModel_NullModel_ThrowsException()
+        {
+            static async Task Index()
+            {
+                using var controller = new ConsentController(Mock.Of<IAgreementConsentService>());
+                await controller.Index((ConsentViewModel)null);
+            }
+
+            Assert.ThrowsAsync<ArgumentNullException>(Index);
+        }
+
+        [Test]
+        public async Task Index_ConsentViewModel_InvalidModelState_ReturnsConsentView()
+        {
+            var expectedModel = new ConsentViewModel();
+
+            using var controller = new ConsentController(Mock.Of<IAgreementConsentService>());
+            controller.ModelState.AddModelError("Test", "Test");
+
+            var result = await controller.Index(expectedModel) as ViewResult;
+
+            Assert.NotNull(result);
+            result.Model.Should().Be(expectedModel);
+        }
+
+        [Test]
+        public async Task Index_ConsentViewModel_ValidReturnUrlAndModel_RedirectsToReturnUrl()
+        {
+            const string subjectId = "SubjectId";
+            var returnUrl = new Uri("http://www.goodurl.co.uk/");
+
+            var mockConsentService = new Mock<IAgreementConsentService>();
+            mockConsentService.Setup(c => c.GrantConsent(It.Is<Uri>(u => u == returnUrl), It.Is<string>(s => s.Equals(subjectId, StringComparison.Ordinal))))
+                .ReturnsAsync(Result.Success(returnUrl));
+
+            using var controller = new ConsentController(mockConsentService.Object)
+            {
+                ControllerContext = ControllerContext(subjectId)
+            };
+
+            var result = await controller.Index(
+                new ConsentViewModel { ReturnUrl = returnUrl }) as RedirectResult;
+
+            Assert.NotNull(result);
+            result.Url.Should().Be(returnUrl.ToString());
+        }
+
+        [Test]
+        public async Task Index_ConsentViewModel_BadReturnUrl_ReturnsErrorView()
+        {
+            var mockConsentService = new Mock<IAgreementConsentService>();
+            mockConsentService.Setup(c => c.GrantConsent(It.IsAny<Uri>(), It.IsAny<string>()))
+                .ReturnsAsync(Result.Failure<Uri>());
+
+            using var controller = new ConsentController(mockConsentService.Object)
+            {
+                ControllerContext = ControllerContext(string.Empty)
+            };
+
+            var result = await controller.Index(new ConsentViewModel()) as ViewResult;
+
+            Assert.NotNull(result);
+            result.ViewName.Should().Be("Error");
+        }
+
+        private static ControllerContext ControllerContext(string subjectId)
+        {
+            var claims = new[] { new Claim(JwtClaimTypes.Subject, subjectId) };
+            var identity = new ClaimsIdentity(claims, "Test");
+            var principal = new ClaimsPrincipal(identity);
+
+            return new ControllerContext
+            {
+                HttpContext = Mock.Of<HttpContext>(c => c.User == principal)
+            };
+        }
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Infrastructure/CatalogueAgreementConsentStoreTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Infrastructure/CatalogueAgreementConsentStoreTests.cs
@@ -1,0 +1,150 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.Models;
+using Moq;
+using NHSD.BuyingCatalogue.Identity.Api.Infrastructure;
+using NHSD.BuyingCatalogue.Identity.Api.Models;
+using NHSD.BuyingCatalogue.Identity.Api.Repositories;
+using NHSD.BuyingCatalogue.Identity.Api.UnitTests.Builders;
+using NUnit.Framework;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Infrastructure
+{
+    [TestFixture]
+    internal sealed class CatalogueAgreementConsentStoreTests
+    {
+        [Test]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "Exception testing")]
+        public void Constructor_IScopeRepository_IUsersRepository_NullScopeRepository_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new CatalogueAgreementConsentStore(null, Mock.Of<IUsersRepository>()));
+        }
+
+        [Test]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "Exception testing")]
+        public void Constructor_IScopeRepository_IUsersRepository_NullUsersRepository_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new CatalogueAgreementConsentStore(Mock.Of<IScopeRepository>(), null));
+        }
+
+        [Test]
+        public void StoreUserConsentAsync_NullConsent_ThrowsException()
+        {
+            var store = new CatalogueAgreementConsentStore(Mock.Of<IScopeRepository>(), Mock.Of<IUsersRepository>());
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await store.StoreUserConsentAsync(null));
+        }
+
+        [Test]
+        public async Task StoreUserConsentAsync_MarksCatalogueAgreementSigned()
+        {
+            const string subjectId = "JulesVerneId";
+
+            var user = ApplicationUserBuilder.Create().Build();
+            var mockUsersRepository = new Mock<IUsersRepository>();
+            mockUsersRepository.Setup(
+                u => u.GetByIdAsync(It.Is<string>(s => s.Equals(subjectId, StringComparison.Ordinal))))
+                .ReturnsAsync(user);
+
+            var store = new CatalogueAgreementConsentStore(Mock.Of<IScopeRepository>(), mockUsersRepository.Object);
+
+            user.CatalogueAgreementSigned.Should().BeFalse();
+
+            await store.StoreUserConsentAsync(new Consent { SubjectId = subjectId });
+
+            user.CatalogueAgreementSigned.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task StoreUserConsentAsync_UpdatesRepository()
+        {
+            var user = ApplicationUserBuilder.Create().Build();
+            var mockUsersRepository = new Mock<IUsersRepository>();
+            mockUsersRepository.Setup(u => u.GetByIdAsync(It.IsAny<string>()))
+                .ReturnsAsync(user);
+
+            var store = new CatalogueAgreementConsentStore(Mock.Of<IScopeRepository>(), mockUsersRepository.Object);
+
+            await store.StoreUserConsentAsync(new Consent());
+
+            mockUsersRepository.Verify(r => r.UpdateAsync(It.Is<ApplicationUser>(u => u == user)), Times.Once());
+        }
+
+        [Test]
+        public async Task GetUserConsentAsync_CatalogueAgreementNotSigned_ReturnsConsentWithNoScopes()
+        {
+            const string clientId = "SomeClient";
+            const string subjectId = "JulesVerneId";
+
+            var expectedConsent = new Consent
+            {
+                ClientId = clientId,
+                Expiration = DateTime.MaxValue,
+                Scopes = null,
+                SubjectId = subjectId,
+            };
+
+            var user = ApplicationUserBuilder.Create().Build();
+            var mockUsersRepository = new Mock<IUsersRepository>();
+            mockUsersRepository.Setup(
+                u => u.GetByIdAsync(It.Is<string>(s => s.Equals(subjectId, StringComparison.Ordinal))))
+                .ReturnsAsync(user);
+
+            var store = new CatalogueAgreementConsentStore(Mock.Of<IScopeRepository>(), mockUsersRepository.Object);
+
+            var actualConsent = await store.GetUserConsentAsync(subjectId, clientId);
+
+            actualConsent.Should().BeEquivalentTo(expectedConsent, o => o.Excluding(c => c.CreationTime));
+        }
+
+        [Test]
+        public async Task GetUserConsentAsync_CatalogueAgreementSigned_ReturnsConsentWithScopes()
+        {
+            const string clientId = "SomeClient";
+            const string subjectId = "JulesVerneId";
+
+            var scopes = new[] { "Scope1", "Scope2" };
+
+            var expectedConsent = new Consent
+            {
+                ClientId = clientId,
+                Expiration = DateTime.MaxValue,
+                Scopes = scopes,
+                SubjectId = subjectId,
+            };
+
+            var mockScopeRepository = new Mock<IScopeRepository>();
+            mockScopeRepository.Setup(s => s.Scopes).Returns(scopes);
+
+            var user = ApplicationUserBuilder
+                .Create()
+                .WithCatalogueAgreementSigned(true)
+                .Build();
+
+            var mockUsersRepository = new Mock<IUsersRepository>();
+            mockUsersRepository.Setup(
+                    u => u.GetByIdAsync(It.Is<string>(s => s.Equals(subjectId, StringComparison.Ordinal))))
+                .ReturnsAsync(user);
+
+            var store = new CatalogueAgreementConsentStore(mockScopeRepository.Object, mockUsersRepository.Object);
+
+            var actualConsent = await store.GetUserConsentAsync(subjectId, clientId);
+
+            actualConsent.Should().BeEquivalentTo(expectedConsent, o => o.Excluding(c => c.CreationTime));
+        }
+
+        [Test]
+        public void RemoveUserConsentAsync_ReturnsCompletedTask()
+        {
+            var store = new CatalogueAgreementConsentStore(Mock.Of<IScopeRepository>(), Mock.Of<IUsersRepository>());
+
+            var response = store.RemoveUserConsentAsync(null, null);
+
+            response.Should().Be(Task.CompletedTask);
+        }
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Repository/ScopeRepositoryTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Repository/ScopeRepositoryTests.cs
@@ -1,0 +1,61 @@
+﻿using FluentAssertions;
+using NHSD.BuyingCatalogue.Identity.Api.Repositories;
+using NHSD.BuyingCatalogue.Identity.Api.Settings;
+using NUnit.Framework;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Repository
+{
+    [TestFixture]
+    internal sealed class ScopeRepositoryTests
+    {
+        [Test]
+        public void Scopes_ApiAndIdentityResources_ReturnsExpectedScopes()
+        {
+            const string scope1 = "Scope1";
+            const string scope2 = "Scope2";
+
+            var expectedScopes = new[] { scope1, "scope2" };
+
+            var apiResources = new[] { new ResourceSetting { ResourceName = scope1 } };
+            var identityResources = new[] { new IdentityResourceSetting { ResourceType = scope2 } };
+
+            var scopeRepository = new ScopeRepository(apiResources, identityResources);
+
+            var actualScopes = scopeRepository.Scopes;
+
+            actualScopes.Should().BeEquivalentTo(expectedScopes);
+        }
+
+        [Test]
+        public void Scopes_ApiResources_ReturnsExpectedScopes()
+        {
+            const string apiScope = "ApiScope1";
+
+            var expectedScopes = new[] { apiScope };
+
+            var apiResources = new[] { new ResourceSetting { ResourceName = apiScope } };
+
+            var scopeRepository = new ScopeRepository(apiResources, null);
+
+            var actualScopes = scopeRepository.Scopes;
+
+            actualScopes.Should().BeEquivalentTo(expectedScopes);
+        }
+
+        [Test]
+        public void Scopes_IdentityResources_ReturnsExpectedScopes()
+        {
+            const string identityScope = "IdentityScope1";
+
+            var expectedScopes = new[] { "identityscope1" };
+
+            var identityResources = new[] { new IdentityResourceSetting { ResourceType = identityScope } };
+
+            var scopeRepository = new ScopeRepository(null, identityResources);
+
+            var actualScopes = scopeRepository.Scopes;
+
+            actualScopes.Should().BeEquivalentTo(expectedScopes);
+        }
+    }
+}

--- a/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Services/AgreementConsentServiceTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Services/AgreementConsentServiceTests.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IdentityServer4.Events;
+using IdentityServer4.Models;
+using IdentityServer4.Services;
+using Moq;
+using NHSD.BuyingCatalogue.Identity.Api.Repositories;
+using NHSD.BuyingCatalogue.Identity.Api.Services;
+using NHSD.BuyingCatalogue.Identity.Common.Results;
+using NUnit.Framework;
+
+namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Services
+{
+    [TestFixture]
+    internal sealed class AgreementConsentServiceTests
+    {
+        [Test]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "Exception testing")]
+        public void Constructor_NullEventService_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new AgreementConsentService(null, Mock.Of<IIdentityServerInteractionService>(), Mock.Of<IScopeRepository>()));
+        }
+
+        [Test]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "Exception testing")]
+        public void Constructor_NullInteractionService_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new AgreementConsentService(Mock.Of<IEventService>(), null, Mock.Of<IScopeRepository>()));
+        }
+
+        [Test]
+        [SuppressMessage("ReSharper", "ObjectCreationAsStatement", Justification = "Exception testing")]
+        public void Constructor_NullScopeRepository_ThrowsException()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new AgreementConsentService(Mock.Of<IEventService>(), Mock.Of<IIdentityServerInteractionService>(), null));
+        }
+
+        [Test]
+        public void IsValidReturnUrl_NullReturnUrl_ThrowsException()
+        {
+            var service = new AgreementConsentService(
+                Mock.Of<IEventService>(),
+                Mock.Of<IIdentityServerInteractionService>(),
+                Mock.Of<IScopeRepository>());
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await service.IsValidReturnUrl(null));
+        }
+
+        [Test]
+        public async Task IsValidReturnUrl_BadReturnUrl_ReturnsFalse()
+        {
+            var service = new AgreementConsentService(
+                Mock.Of<IEventService>(),
+                Mock.Of<IIdentityServerInteractionService>(),
+                Mock.Of<IScopeRepository>());
+
+            var isValidReturnUrl = await service.IsValidReturnUrl(new Uri("https://www.badurl.co.uk/"));
+
+            isValidReturnUrl.Should().BeFalse();
+        }
+
+        [Test]
+        public async Task IsValidReturnUrl_ValidReturnUrl_ReturnsFalse()
+        {
+            var mockInteractionService = new Mock<IIdentityServerInteractionService>();
+            mockInteractionService.Setup(i => i.GetAuthorizationContextAsync(It.IsNotNull<string>()))
+                .ReturnsAsync(new AuthorizationRequest());
+
+            var service = new AgreementConsentService(
+                Mock.Of<IEventService>(),
+                mockInteractionService.Object,
+                Mock.Of<IScopeRepository>());
+
+            var isValidReturnUrl = await service.IsValidReturnUrl(new Uri("https://www.goodurl.co.uk/"));
+
+            isValidReturnUrl.Should().BeTrue();
+        }
+
+        [Test]
+        public async Task GrantConsent_BadReturnUrl_ReturnsFailure()
+        {
+            var service = new AgreementConsentService(
+                Mock.Of<IEventService>(),
+                Mock.Of<IIdentityServerInteractionService>(),
+                Mock.Of<IScopeRepository>());
+
+            var result = await service.GrantConsent(new Uri("https://www.badurl.co.uk/"), null);
+
+            result.Should().Be(Result.Failure<Uri>());
+        }
+
+        [Test]
+        public async Task GrantConsent_ValidReturnUrl_GrantsExpectedConsent()
+        {
+            AuthorizationRequest actualContext = null;
+            ConsentResponse actualConsentResponse = null;
+
+            void GrantConsentCallback(AuthorizationRequest context, ConsentResponse response, string subject)
+            {
+                actualContext = context;
+                actualConsentResponse = response;
+            }
+
+            var expectedContext = new AuthorizationRequest();
+            var mockInteractionService = new Mock<IIdentityServerInteractionService>();
+            mockInteractionService.Setup(i => i.GetAuthorizationContextAsync(It.IsNotNull<string>()))
+                .ReturnsAsync(expectedContext);
+
+            Expression<Func<IIdentityServerInteractionService, Task>> grantConsent = i => i.GrantConsentAsync(
+                It.IsNotNull<AuthorizationRequest>(),
+                It.IsNotNull<ConsentResponse>(),
+                It.IsAny<string>());
+
+            mockInteractionService.Setup(grantConsent)
+                .Callback<AuthorizationRequest, ConsentResponse, string>(GrantConsentCallback);
+
+            var expectedScopes = new[] { "Scope1", "Scope2" };
+            var mockScopeRepository = Mock.Of<IScopeRepository>(r => r.Scopes == expectedScopes);
+
+            var service = new AgreementConsentService(
+                Mock.Of<IEventService>(),
+                mockInteractionService.Object,
+                mockScopeRepository);
+
+            await service.GrantConsent(new Uri("https://www.goodurl.co.uk/"), null);
+
+            mockInteractionService.Verify(grantConsent, Times.Once());
+
+            actualContext.Should().Be(expectedContext);
+            actualConsentResponse.Should().BeEquivalentTo(new ConsentResponse { RememberConsent = true, ScopesConsented = expectedScopes });
+        }
+
+        [Test]
+        public async Task GrantConsent_ValidReturnUrl_RaisesConsentGrantedEvent()
+        {
+            const string subjectId = "SubjectId";
+            const string clientId = "ClientId";
+
+            var requestedScopes = new[] { "Scope1" };
+
+            var context = new AuthorizationRequest { ClientId = clientId, ScopesRequested = requestedScopes };
+            var mockInteractionService = new Mock<IIdentityServerInteractionService>();
+            mockInteractionService.Setup(i => i.GetAuthorizationContextAsync(It.IsNotNull<string>()))
+                .ReturnsAsync(context);
+
+            var expectedScopes = new[] { "Scope1", "Scope2" };
+            var mockScopeRepository = Mock.Of<IScopeRepository>(r => r.Scopes == expectedScopes);
+
+            Expression<Action<IEventService>> raise = e => e.RaiseAsync(It.IsNotNull<Event>());
+            Event actualEvent = null;
+
+            var mockEventService = new Mock<IEventService>();
+            mockEventService.Setup(raise)
+                .Callback<Event>(e => actualEvent = e);
+
+            var service = new AgreementConsentService(
+                mockEventService.Object,
+                mockInteractionService.Object,
+                mockScopeRepository);
+
+            await service.GrantConsent(new Uri("https://www.goodurl.co.uk/"), subjectId);
+
+            mockEventService.Verify(raise, Times.Once());
+
+            actualEvent.Should().BeOfType<ConsentGrantedEvent>();
+            actualEvent.Should().BeEquivalentTo(new ConsentGrantedEvent(
+                subjectId,
+                clientId,
+                requestedScopes,
+                expectedScopes,
+                true));
+        }
+
+        [Test]
+        public async Task GrantConsent_ValidReturnUrl_ReturnsSuccess()
+        {
+            var mockInteractionService = new Mock<IIdentityServerInteractionService>();
+            mockInteractionService.Setup(i => i.GetAuthorizationContextAsync(It.IsNotNull<string>()))
+                .ReturnsAsync(new AuthorizationRequest());
+
+            var service = new AgreementConsentService(
+                Mock.Of<IEventService>(),
+                mockInteractionService.Object,
+                Mock.Of<IScopeRepository>());
+
+            var returnUrl = new Uri("https://www.goodurl.co.uk/");
+            var result = await service.GrantConsent(returnUrl, null);
+
+            result.Should().Be(Result.Success(returnUrl));
+        }
+
+        [Test]
+        public void GrantConsent_NullReturnUrl_ThrowsException()
+        {
+            var service = new AgreementConsentService(
+                Mock.Of<IEventService>(),
+                Mock.Of<IIdentityServerInteractionService>(),
+                Mock.Of<IScopeRepository>());
+
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await service.GrantConsent(null, string.Empty));
+        }
+    }
+}


### PR DESCRIPTION
There are some outstanding tasks still required, particularly around the styling of the consent view and its content, so I have added the following tasks to [story 3924](https://dev.azure.com/BuyingCatalog/Buying%20Catalogue/_workitems/edit/3924):

[API/FE – Correct the styling of the consent view (6331)](https://dev.azure.com/BuyingCatalog/Buying%20Catalogue/_workitems/edit/6331)
[API – Confirm correct validation error message (6329)](https://dev.azure.com/BuyingCatalog/Buying%20Catalogue/_workitems/edit/6329)
[API – Confirm correct agreement text re privacy (6330)](https://dev.azure.com/BuyingCatalog/Buying%20Catalogue/_workitems/edit/6330)
[API – Add integration tests (6332)](https://dev.azure.com/BuyingCatalog/Buying%20Catalogue/_workitems/edit/6332)
[API – Move agreement text to DB (6333)](https://dev.azure.com/BuyingCatalog/Buying%20Catalogue/_workitems/edit/6333)

AB#6135
AB#6173