### PR TITLE
changed bobs agreement value to 1

### DIFF
--- a/src/NHSD.BuyingCatalogue.Identity.UserDatabase/Deployment/CreateTestUsers.sql
+++ b/src/NHSD.BuyingCatalogue.Identity.UserDatabase/Deployment/CreateTestUsers.sql
@@ -40,7 +40,7 @@ BEGIN
     )
 	VALUES
 	(@aliceId, @aliceEmail, @aliceNormalizedEmail, @aliceEmail, @aliceNormalizedEmail, 0, NEWID(), @phoneNumber, 1, 1, @alicePassword, 0, 'NNJ4SLBPCVUDKXAQXJHCBKQTFEYUAPBC', 0, 'Alice', 'Smith', @aliceOrganisationId, 'Buyer', 0, 1),
-	(@bobId, @bobEmail, @bobNormalizedEmail, @bobEmail, @bobNormalizedEmail, 0, NEWID(), @phoneNumber, 1, 1, @bobPassword, 0, 'OBDOPOU5YQ5WQXCR3DITKL6L5IDPYHHJ', 0, 'Bob', 'Smith', @bobOrganisationId, 'Authority', 0, 0);
+	(@bobId, @bobEmail, @bobNormalizedEmail, @bobEmail, @bobNormalizedEmail, 0, NEWID(), @phoneNumber, 1, 1, @bobPassword, 0, 'OBDOPOU5YQ5WQXCR3DITKL6L5IDPYHHJ', 0, 'Bob', 'Smith', @bobOrganisationId, 'Authority', 0, 1);
 
 	INSERT INTO dbo.AspNetUserClaims (ClaimType, ClaimValue, UserId)
 	VALUES


### PR DESCRIPTION
It would be nice if Bobs catalogue agreement was already set, so that when i run tests locally for the first time after launching, the accept agreement doesn't appear and cause the acceptance tests to fail.

Let's see if any unit/integration tests fail.

If everything passes, would there be any harm in this? If there's a valid reason for having bob's value set to 0, I'm happy to leave this out. 