### PR TITLE
Make config consistent with the ordering API

### DIFF
--- a/src/NHSD.BuyingCatalogue.Identity.Api/Services/PasswordService.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Services/PasswordService.cs
@@ -79,7 +79,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Services
                 throw new ArgumentNullException(nameof(callback));
 
             await emailService.SendEmailAsync(
-                settings.EmailMessageTemplate,
+                settings.EmailMessage,
                 new EmailAddress(user.Email, user.DisplayName),
                 callback);
         }

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Services/RegistrationService.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Services/RegistrationService.cs
@@ -46,7 +46,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Services
             var user = token.User;
 
             await emailService.SendEmailAsync(
-                settings.EmailMessageTemplate,
+                settings.EmailMessage,
                 new EmailAddress(user.Email, user.DisplayName),
                 passwordResetCallback.GetPasswordResetCallback(token));
         }

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Settings/PasswordResetSettings.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Settings/PasswordResetSettings.cs
@@ -11,6 +11,6 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Settings
         /// Gets or sets the sender, subject and content of
         /// the password reset e-mail message.
         /// </summary>
-        public EmailMessageTemplate EmailMessageTemplate { get; set; }
+        public EmailMessageTemplate EmailMessage { get; set; }
     }
 }

--- a/src/NHSD.BuyingCatalogue.Identity.Api/Settings/RegistrationSettings.cs
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/Settings/RegistrationSettings.cs
@@ -11,6 +11,6 @@ namespace NHSD.BuyingCatalogue.Identity.Api.Settings
         /// Gets or sets the sender, subject and content of
         /// the e-mail message to send to a new user.
         /// </summary>
-        public EmailMessageTemplate EmailMessageTemplate { get; set; }
+        public EmailMessageTemplate EmailMessage { get; set; }
     }
 }

--- a/src/NHSD.BuyingCatalogue.Identity.Api/appsettings.json
+++ b/src/NHSD.BuyingCatalogue.Identity.Api/appsettings.json
@@ -71,7 +71,7 @@
     "emailSubjectPrefix": ""
   },
   "passwordReset": {
-    "emailMessageTemplate": {
+    "emailMessage": {
       "sender": {
         "address": "noreply@buyingcatalogue.nhs.uk",
         "displayName": "Buying Catalogue Team"
@@ -82,7 +82,7 @@
     }
   },
   "registration": {
-    "emailMessageTemplate": {
+    "emailMessage": {
       "sender": {
         "address": "noreply@buyingcatalogue.nhs.uk",
         "displayName": "Buying Catalogue Team"

--- a/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Services/PasswordServiceTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Services/PasswordServiceTests.cs
@@ -157,7 +157,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Services
             var mockEmailService = new Mock<IEmailService>();
             var registrationService = new PasswordService(
                 mockEmailService.Object,
-                new PasswordResetSettings { EmailMessageTemplate = template },
+                new PasswordResetSettings { EmailMessage = template },
                 MockUserManager.Object);
 
             await registrationService.SendResetEmailAsync(
@@ -181,7 +181,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Services
             var mockEmailService = new MockEmailService();
             var registrationService = new PasswordService(
                 mockEmailService,
-                new PasswordResetSettings { EmailMessageTemplate = template },
+                new PasswordResetSettings { EmailMessage = template },
                 MockUserManager.Object);
 
             await registrationService.SendResetEmailAsync(
@@ -206,7 +206,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Services
 
             var registrationService = new PasswordService(
                 mockEmailService,
-                new PasswordResetSettings { EmailMessageTemplate = template },
+                new PasswordResetSettings { EmailMessage = template },
                 MockUserManager.Object);
 
             await registrationService.SendResetEmailAsync(
@@ -232,7 +232,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Services
             var mockEmailService = new MockEmailService();
             var registrationService = new PasswordService(
                 mockEmailService,
-                new PasswordResetSettings { EmailMessageTemplate = template },
+                new PasswordResetSettings { EmailMessage = template },
                 MockUserManager.Object);
 
             await registrationService.SendResetEmailAsync(

--- a/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Services/RegistrationServiceTests.cs
+++ b/tests/NHSD.BuyingCatalogue.Identity.Api.UnitTests/Services/RegistrationServiceTests.cs
@@ -71,7 +71,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Services
                 PlainTextContent = "Text",
             };
 
-            var settings = new RegistrationSettings { EmailMessageTemplate = inputMessage };
+            var settings = new RegistrationSettings { EmailMessage = inputMessage };
             var mockEmailService = new Mock<IEmailService>();
             var mockPasswordResetCallback = Mock.Of<IPasswordResetCallback>(
                 c => c.GetPasswordResetCallback(It.IsAny<PasswordResetToken>()) == new Uri("https://www.google.co.uk/"));
@@ -106,7 +106,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Services
             var registrationService = new RegistrationService(
                 mockEmailService,
                 Mock.Of<IPasswordResetCallback>(),
-                new RegistrationSettings { EmailMessageTemplate = template });
+                new RegistrationSettings { EmailMessage = template });
 
             await registrationService.SendInitialEmailAsync(
                 new PasswordResetToken("Token", ApplicationUserBuilder.Create().Build()));
@@ -130,7 +130,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Services
             var registrationService = new RegistrationService(
                 mockEmailService,
                 Mock.Of<IPasswordResetCallback>(),
-                new RegistrationSettings { EmailMessageTemplate = template });
+                new RegistrationSettings { EmailMessage = template });
 
             await registrationService.SendInitialEmailAsync(new PasswordResetToken("Token", user));
 
@@ -157,7 +157,7 @@ namespace NHSD.BuyingCatalogue.Identity.Api.UnitTests.Services
             var registrationService = new RegistrationService(
                 mockEmailService,
                 passwordResetCallback,
-                new RegistrationSettings { EmailMessageTemplate = template });
+                new RegistrationSettings { EmailMessage = template });
 
             await registrationService.SendInitialEmailAsync(
                 new PasswordResetToken("Token", ApplicationUserBuilder.Create().Build()));


### PR DESCRIPTION
Resolves an issue with a mismatch between environment variable definitions in the helm charts and those in the application.

Activity: [AB#12187](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/12187)
Task: [AB#12452](https://buyingcatalog.visualstudio.com/c5f97979-5b03-4d10-ba8d-871d0526b408/_workitems/edit/12452)